### PR TITLE
Forced hop

### DIFF
--- a/examples/ala3_openmm/ala3_openmm_nve.py
+++ b/examples/ala3_openmm/ala3_openmm_nve.py
@@ -7,6 +7,7 @@ import os
 import shutil
 
 import mudslide
+from mudslide.units import *
 import yaml
 
 import openmm
@@ -29,7 +30,7 @@ if __name__ == "__main__":
     velocities = mudslide.math.boltzmann_velocities(masses, 300.0, seed=1234)
     KE = 0.5 * np.sum(velocities**2 * masses)
 
-    traj = mudslide.AdiabaticMD(mm, mm._position, velocities, dt=40, max_steps=1000)
+    traj = mudslide.AdiabaticMD(mm, mm._position, velocities, dt=fs, max_steps=1000)
     results = traj.simulate()
 
     mudslide.io.write_trajectory_xyz(mm, results, 'ala3.xyz')

--- a/examples/ala3_openmm/ala3_openmm_nvt.py
+++ b/examples/ala3_openmm/ala3_openmm_nvt.py
@@ -3,11 +3,9 @@
 """Unit testing for OpenMM functionalities"""
 
 import numpy as np
-import os
-import shutil
 
 import mudslide
-import yaml
+from mudslide.units import *
 
 import openmm
 import openmm.app
@@ -31,8 +29,7 @@ if __name__ == "__main__":
     print("Initial kinetic energy:", KE)
     print("Initial temperature: ", KE / (0.5 * mm.ndof() * mudslide.constants.boltzmann))
 
-    fs = mudslide.constants.fs_to_au
-    traj = mudslide.AdiabaticMD(mm, mm._position, velocities, propagator={ "type": "nhc", "temperature": 300, "timescale": 10*fs }, dt=1.0*fs, max_steps=10000, remove_com_every=0)
+    traj = mudslide.AdiabaticMD(mm, mm._position, velocities, propagator={ "type": "nhc", "temperature": 300, "timescale": 10*fs }, dt=fs, max_steps=10000, remove_com_every=0)
     results = traj.simulate()
 
     mudslide.io.write_trajectory_xyz(mm, results, 'ala3.xyz', every=10)

--- a/examples/azobenzene_aimd_turbomole/azobenzene_300K_aimd.py
+++ b/examples/azobenzene_aimd_turbomole/azobenzene_300K_aimd.py
@@ -1,4 +1,6 @@
 import mudslide
+from mudslide.units import *
+
 import numpy as np
 
 if __name__ == "__main__":
@@ -22,7 +24,7 @@ if __name__ == "__main__":
                                     "temperature": 300
                                 },
                                 tracer="yaml",
-                                dt=0.5 * mudslide.fs_to_au,
+                                dt=0.5 * fs,
                                 max_steps=100,
                                 remove_com_every=1,
                                 remove_angular_momentum_every=1)

--- a/examples/azobenzene_aimd_turbomole/azobenzene_300K_aimd.py
+++ b/examples/azobenzene_aimd_turbomole/azobenzene_300K_aimd.py
@@ -11,10 +11,8 @@ if __name__ == "__main__":
     X = model._position
     velocities = mudslide.math.boltzmann_velocities(model.mass,
                                                     temperature=300.0,
+                                                    coords=X,
                                                     seed=1234)
-    velocities = mudslide.util.remove_angular_momentum(
-        velocities.reshape((-1, 3)),
-        model.mass.reshape((-1, 3))[:, 0], X.reshape((-1, 3))).flatten()
 
     traj = mudslide.AdiabaticMD(model,
                                 X,

--- a/examples/azobenzene_fssh_turbomole/azobenzene_fssh.py
+++ b/examples/azobenzene_fssh_turbomole/azobenzene_fssh.py
@@ -11,10 +11,8 @@ if __name__ == "__main__":
     X = model._position
     velocities = mudslide.math.boltzmann_velocities(model.mass,
                                                     temperature=200.0,
+                                                    coords=X,
                                                     seed=1234)
-    velocities = mudslide.util.remove_angular_momentum(
-        velocities.reshape((-1, 3)),
-        model.mass.reshape((-1, 3))[:, 0], X.reshape((-1, 3))).flatten()
 
     traj = mudslide.SurfaceHoppingMD(model,
                                      X,

--- a/examples/azobenzene_fssh_turbomole/azobenzene_fssh.py
+++ b/examples/azobenzene_fssh_turbomole/azobenzene_fssh.py
@@ -20,6 +20,7 @@ if __name__ == "__main__":
                                      1,
                                      tracer="yaml",
                                      dt=fs,
+                                     forced_hop_threshold=0.2 * eV,
                                      max_steps=10)
 
     results = traj.simulate()

--- a/examples/azobenzene_fssh_turbomole/azobenzene_fssh.py
+++ b/examples/azobenzene_fssh_turbomole/azobenzene_fssh.py
@@ -1,4 +1,6 @@
 import mudslide
+from mudslide.units import *
+
 import numpy as np
 
 if __name__ == "__main__":
@@ -19,7 +21,7 @@ if __name__ == "__main__":
                                      velocities,
                                      1,
                                      tracer="yaml",
-                                     dt=mudslide.fs_to_au,
+                                     dt=fs,
                                      max_steps=10)
 
     results = traj.simulate()

--- a/examples/harmonic_water/water_300K_NHC.py
+++ b/examples/harmonic_water/water_300K_NHC.py
@@ -13,10 +13,8 @@ model = mudslide.models.HarmonicModel.from_dict(water_model)
 x = np.array(model.x0)
 velocities = mudslide.math.boltzmann_velocities(model.mass,
                                                 temperature=500.0,
+                                                coords=x,
                                                 seed=1234)
-velocities = mudslide.util.remove_angular_momentum(
-    velocities.reshape((-1, 3)),
-    model.mass.reshape((-1, 3))[:, 0], x.reshape((-1, 3))).flatten()
 
 traj = mudslide.AdiabaticMD(model,
                             x,

--- a/examples/harmonic_water/water_300K_NHC.py
+++ b/examples/harmonic_water/water_300K_NHC.py
@@ -1,5 +1,7 @@
-import json
 import mudslide
+from mudslide.units import *
+
+import json
 import numpy as np
 
 mudslide.print_header()
@@ -23,7 +25,7 @@ traj = mudslide.AdiabaticMD(model,
                                 "type": "nhc",
                                 "temperature": 300
                             },
-                            dt=0.5 * mudslide.fs_to_au,
+                            dt=0.5 * fs,
                             max_steps=30000,
                             remove_com_every=1,
                             remove_angular_momentum_every=1)

--- a/examples/harmonic_water/water_NVE_VV.py
+++ b/examples/harmonic_water/water_NVE_VV.py
@@ -13,10 +13,8 @@ model = mudslide.models.HarmonicModel.from_dict(water_model)
 x = np.array(model.x0)
 velocities = mudslide.math.boltzmann_velocities(model.mass,
                                                 temperature=500.0,
+                                                coords=x,
                                                 seed=1234)
-velocities = mudslide.util.remove_angular_momentum(
-    velocities.reshape((-1, 3)),
-    model.mass.reshape((-1, 3))[:, 0], x.reshape((-1, 3))).flatten()
 
 traj = mudslide.AdiabaticMD(model,
                             x,

--- a/examples/harmonic_water/water_NVE_VV.py
+++ b/examples/harmonic_water/water_NVE_VV.py
@@ -1,5 +1,7 @@
-import json
 import mudslide
+from mudslide.units import *
+
+import json
 import numpy as np
 
 mudslide.print_header()
@@ -10,7 +12,7 @@ model = mudslide.models.HarmonicModel.from_dict(water_model)
 
 x = np.array(model.x0)
 velocities = mudslide.math.boltzmann_velocities(model.mass,
-                                                temperature=10000.0,
+                                                temperature=500.0,
                                                 seed=1234)
 velocities = mudslide.util.remove_angular_momentum(
     velocities.reshape((-1, 3)),
@@ -19,7 +21,7 @@ velocities = mudslide.util.remove_angular_momentum(
 traj = mudslide.AdiabaticMD(model,
                             x,
                             velocities,
-                            dt=mudslide.fs_to_au * 0.5,
+                            dt=0.5 * fs,
                             max_steps=500,
                             remove_com_every=1,
                             remove_angular_momentum_every=1)

--- a/mudslide/__init__.py
+++ b/mudslide/__init__.py
@@ -8,6 +8,7 @@ nonadiabatic molecular dynamics.
 from .version import __version__
 from .header import print_header
 
+from . import units
 from . import models
 from . import math
 from . import io

--- a/mudslide/adiabatic_propagator.py
+++ b/mudslide/adiabatic_propagator.py
@@ -10,7 +10,7 @@ from typing import Any, Dict
 
 import numpy as np
 
-from .constants import fs_to_au, boltzmann
+from .constants import fs_to_au, boltzmann, amu_to_au
 from .propagator import Propagator_
 from .util import remove_center_of_mass_motion, remove_angular_momentum
 
@@ -165,7 +165,7 @@ class NoseHooverChainPropagator(Propagator_):
         print(f"  Temperature: {temperature:.2f} K")
         print(f"  Number of chains: {nchains}")
         print(f"  Timescale: {timescale / fs_to_au:.2f} fs")
-        print(f"  Thermostat mass: {self.nh_mass}")
+        print(f"  Thermostat mass: {self.nh_mass / amu_to_au} amu")
 
     def nhc_step(self, velocity, mass, dt: float):
         """Move forward one step in the extended system variables.

--- a/mudslide/io.py
+++ b/mudslide/io.py
@@ -11,7 +11,7 @@ def write_xyz(coords, atom_types, file, comment=""):
     acoords = coords * bohr_to_angstrom
     for atom, coord in zip(atom_types, acoords):
         atom = atom.capitalize()
-        file.write(f"{atom} {coord[0]:.12f} {coord[1]:.12f} {coord[2]:.12f}\n")
+        file.write(f"{atom:3s} {coord[0]:20.12f} {coord[1]:20.12f} {coord[2]:20.12f}\n")
 
 def write_trajectory_xyz(model, trace, filename, every=1):
     """Write trajectory to XYZ file"""

--- a/mudslide/models/turbomole_model.py
+++ b/mudslide/models/turbomole_model.py
@@ -385,11 +385,11 @@ class TMModel(ElectronicModel_):
         elements, X = self.control.read_coords()
         nparts, ndims = X.shape
         self._position = X.flatten()
-        self._elements = elements
         self.states = states
         ElectronicModel_.__init__(self, nstates=len(self.states), ndims=ndims, nparticles=nparts,
+                                atom_types=elements,
                                 representation=representation, reference=reference)
-        self.mass = self.control.get_masses(self._elements)
+        self.mass = self.control.get_masses(elements)
 
         self.expert = expert
 
@@ -470,7 +470,7 @@ class TMModel(ElectronicModel_):
         coordline += 1
         for i, coord_list in enumerate(X):
             x, y, z = coord_list[:3]
-            s = self._elements[i]
+            s = self.atom_types[i]
             lines[coordline] = f"{x:26.16e} {y:28.16e} {z:28.16e} {s:>7}\n"
             coordline += 1
 

--- a/mudslide/units.py
+++ b/mudslide/units.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""Physical constants"""
+
+# mudslide always uses atomic units. These are convenience definitions
+# that let you write things like dt=0.5*fs without having to care what the base units are.
+
+# Energy units
+Hartree = 1.0
+eV = 1.0 / 27.211386245988
+kJmol = 1.0 / 2625.499639
+kcalmol = 1.0 / 627.5094740631
+
+# mass
+amu = 1822.8884862
+electron_mass = 1.0
+
+# distance
+bohr = 1.0
+angstrom = 1.0 / 0.52917721092
+nm = 10.0 * angstrom
+
+# From NIST CODATA 2024 (https://physics.nist.gov/cgi-bin/cuu/Value?aut)
+autime = 1.0
+fs = 1e-15 / 2.4188843265857e-17
+ps = 1e-12 / 2.4188843265857e-17

--- a/test/test_math.py
+++ b/test/test_math.py
@@ -6,6 +6,8 @@ import unittest
 import sys
 
 from mudslide import poisson_prob_scale
+from mudslide.math import boltzmann_velocities
+from mudslide.constants import boltzmann
 import numpy as np
 
 
@@ -20,6 +22,94 @@ class TestMath(unittest.TestCase):
         for i, x in enumerate(args):
             self.assertAlmostEqual(fx[i], refs[i], places=10)
             self.assertAlmostEqual(poisson_prob_scale(args[i]), refs[i], places=10)
+
+
+class TestBoltzmannVelocities(unittest.TestCase):
+    """Test Suite for boltzmann_velocities function"""
+
+    def setUp(self):
+        self.natom = 4
+        self.temperature = 300.0
+        self.seed = 42
+        # masses for 4 atoms, repeated for each DOF
+        atom_masses = np.array([16.0, 1.0, 1.0, 12.0])
+        self.mass_flat = np.repeat(atom_masses, 3)  # shape (12,)
+        self.mass_2d = np.column_stack([atom_masses] * 3)  # shape (4, 3)
+        # coordinates for angular momentum removal
+        self.coords_flat = np.array([
+            0.0, 0.0, 0.0,
+            1.0, 0.0, 0.0,
+            0.0, 1.0, 0.0,
+            0.0, 0.0, 1.0,
+        ])
+        self.coords_2d = self.coords_flat.reshape((4, 3))
+
+    def test_flat_input_returns_flat_output(self):
+        """Flat mass input (ndof,) should return flat velocities (ndof,)"""
+        v = boltzmann_velocities(self.mass_flat, self.temperature, seed=self.seed)
+        self.assertEqual(v.shape, self.mass_flat.shape)
+
+    def test_2d_input_returns_2d_output(self):
+        """2D mass input (natom, 3) should return 2D velocities (natom, 3)"""
+        v = boltzmann_velocities(self.mass_2d, self.temperature, seed=self.seed)
+        self.assertEqual(v.shape, self.mass_2d.shape)
+
+    def test_flat_and_2d_give_same_velocities(self):
+        """Flat and 2D inputs with same seed should produce equivalent velocities"""
+        v_flat = boltzmann_velocities(self.mass_flat, self.temperature, seed=self.seed)
+        v_2d = boltzmann_velocities(self.mass_2d, self.temperature, seed=self.seed)
+        np.testing.assert_allclose(v_flat, v_2d.reshape(-1), atol=1e-12)
+
+    def test_com_removed(self):
+        """Center of mass momentum should be zero after removal"""
+        v = boltzmann_velocities(self.mass_flat, self.temperature,
+                                 remove_translation=True, seed=self.seed)
+        v3 = v.reshape((-1, 3))
+        atom_masses = self.mass_flat.reshape((-1, 3))[:, 0]
+        com_momentum = np.sum(v3 * atom_masses[:, np.newaxis], axis=0)
+        np.testing.assert_allclose(com_momentum, 0.0, atol=1e-10)
+
+    def test_angular_momentum_removed(self):
+        """Angular momentum should be approximately zero after removal"""
+        v = boltzmann_velocities(self.mass_flat, self.temperature,
+                                 remove_translation=True,
+                                 coords=self.coords_flat,
+                                 remove_rotation=True,
+                                 seed=self.seed)
+        v3 = v.reshape((-1, 3))
+        atom_masses = self.mass_flat.reshape((-1, 3))[:, 0]
+        momentum = v3 * atom_masses[:, np.newaxis]
+        angular_momentum = np.cross(self.coords_2d, momentum).sum(axis=0)
+        np.testing.assert_allclose(angular_momentum, 0.0, atol=1e-10)
+
+    def test_angular_momentum_removed_2d(self):
+        """Angular momentum removal should work with 2D mass and coords"""
+        v = boltzmann_velocities(self.mass_2d, self.temperature,
+                                 remove_translation=True,
+                                 coords=self.coords_2d,
+                                 remove_rotation=True,
+                                 seed=self.seed)
+        self.assertEqual(v.shape, self.mass_2d.shape)
+        atom_masses = self.mass_2d[:, 0]
+        momentum = v * atom_masses[:, np.newaxis]
+        angular_momentum = np.cross(self.coords_2d, momentum).sum(axis=0)
+        np.testing.assert_allclose(angular_momentum, 0.0, atol=1e-10)
+
+    def test_angular_momentum_auto_enabled_with_coords(self):
+        """Rotation removal should be auto-enabled when coords are provided"""
+        v = boltzmann_velocities(self.mass_flat, self.temperature,
+                                 coords=self.coords_flat, seed=self.seed)
+        v3 = v.reshape((-1, 3))
+        atom_masses = self.mass_flat.reshape((-1, 3))[:, 0]
+        momentum = v3 * atom_masses[:, np.newaxis]
+        angular_momentum = np.cross(self.coords_2d, momentum).sum(axis=0)
+        np.testing.assert_allclose(angular_momentum, 0.0, atol=1e-10)
+
+    def test_remove_rotation_without_coords_raises(self):
+        """Requesting rotation removal without coords should raise ValueError"""
+        with self.assertRaises(ValueError):
+            boltzmann_velocities(self.mass_flat, self.temperature,
+                                 remove_rotation=True, seed=self.seed)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds an option to force a hop to the lowest energy state if the gap falls below a threshold.
Also:
- made a units module so you can do things like set the gap threshold as `0.2 * eV`
- fixed boltzmann_velocities to work regardless of shape of input
- optionally removed rotations while generating boltzmann velocities